### PR TITLE
Fix: Auto-version workflow case sensitivity and deployment bundle

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -89,8 +89,8 @@ jobs:
         run: |
           mkdir -p dist
           cp -r site/* dist/
-          cp package.json dist/
-          cp README.md dist/
+          cp package.json package-lock.json dist/
+          cp readme.md dist/
           tar -czf tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz dist/
 
       - name: Generate build provenance attestation


### PR DESCRIPTION
## Critical Fix for Auto-Version Workflow

### 🚨 Problem
The auto-version workflow fails on Linux/Ubuntu runners with:
```
cp: cannot stat 'README.md': No such file or directory
Error: Process completed with exit code 1
```

### 🔧 Root Cause
- **Case sensitivity**: Workflow tries to copy `README.md` but file is `readme.md`
- **Missing dependency lock**: `package-lock.json` not included in deployment bundle

### ✅ Solution
1. **Fixed filename case**: `README.md` → `readme.md`
2. **Added package-lock.json**: For reproducible builds
3. **Both changes in deployment bundle creation**

### 📋 Changes
```yaml
# Before
cp package.json dist/
cp README.md dist/

# After  
cp package.json package-lock.json dist/
cp readme.md dist/
```

### 🎯 Impact
- ✅ Releases will now work on Linux/Ubuntu CI runners
- ✅ Deployment bundles include lock file for reproducible installs
- ✅ No more failed auto-version workflows

**Priority**: Critical - blocks all future releases

🤖 Generated with [Claude Code](https://claude.ai/code)