### PR TITLE
Fix: Replace manual git operations with GitHub release action

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -61,6 +61,12 @@ jobs:
           CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
           BUMP_TYPE="${{ steps.version_type.outputs.type }}"
 
+          # Validate version format (must be x.y.z)
+          if ! echo "$CURRENT_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid version format '$CURRENT_VERSION'. Expected format: x.y.z"
+            exit 1
+          fi
+
           # Calculate new version based on semver
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
           MAJOR=${VERSION_PARTS[0]}
@@ -79,6 +85,10 @@ jobs:
               ;;
             patch)
               PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "Error: Invalid BUMP_TYPE '$BUMP_TYPE'. Must be one of: major, minor, patch."
+              exit 1
               ;;
           esac
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -55,11 +55,34 @@ jobs:
           CURRENT=$(node -p "require('./package.json').version")
           echo "version=$CURRENT" >> $GITHUB_OUTPUT
 
-      - name: Bump version
+      - name: Calculate new version
         id: bump_version
         run: |
-          npm version ${{ steps.version_type.outputs.type }} --no-git-tag-version
-          NEW_VERSION=$(node -p "require('./package.json').version")
+          CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
+          BUMP_TYPE="${{ steps.version_type.outputs.type }}"
+
+          # Calculate new version based on semver
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+
+          case $BUMP_TYPE in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
 
@@ -104,27 +127,11 @@ jobs:
         with:
           subject-path: tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz
 
-      - name: Commit version bump
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add package.json
-          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.version }}"
-
-      - name: Create and push tag
-        run: |
-          git tag ${{ steps.bump_version.outputs.tag }}
-          git push origin main
-          git push origin ${{ steps.bump_version.outputs.tag }}
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release with Tag
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           tag_name: ${{ steps.bump_version.outputs.tag }}
-          release_name: Release ${{ steps.bump_version.outputs.tag }}
+          name: Release ${{ steps.bump_version.outputs.tag }}
           body: |
             ## Auto-generated Release ${{ steps.bump_version.outputs.tag }}
 
@@ -141,15 +148,8 @@ jobs:
             ### Downloads
             - **Deployment bundle**: [tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz](https://github.com/${{ github.repository }}/releases/download/${{ steps.bump_version.outputs.tag }}/tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz) (signed)
             - Source code: [zip](https://github.com/${{ github.repository }}/archive/${{ steps.bump_version.outputs.tag }}.zip) | [tar.gz](https://github.com/${{ github.repository }}/archive/${{ steps.bump_version.outputs.tag }}.tar.gz)
+          files: |
+            tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz
           draft: false
           prerelease: false
-
-      - name: Upload deployment bundle
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz
-          asset_name: tfl-status-${{ steps.bump_version.outputs.tag }}.tar.gz
-          asset_content_type: application/gzip
+          make_latest: true


### PR DESCRIPTION
## 🚨 Critical Fix for Auto-Version Workflow

### Problem
The auto-version workflow violates multiple repository rules:
- ❌ **Changes must be made through a pull request** - direct pushes to main
- ❌ **Commits must have verified signatures** - workflow commits not signed  
- ❌ **Code scanning waiting for results** - push triggers fail status checks
- ❌ **6 of 6 required status checks expected** - bypassing protection

### Root Cause
Manual git operations in workflow:
```yaml
git commit -m "chore: bump version"
git tag v1.0.1
git push origin main        # ← Violates branch protection
git push origin v1.0.1      # ← Violates signing requirements
```

### ✅ Solution
Replace manual operations with modern GitHub release action:

**Before** (problematic):
- Manual `npm version` + `git commit`
- Direct `git push` to protected main
- Deprecated `actions/create-release@v1`
- Separate asset upload step

**After** (compliant):
- Semver calculation (no package.json changes)
- `softprops/action-gh-release@v2.0.8`
- Creates tags through GitHub API
- Integrated file uploads

### 🔧 Key Changes
1. **Removed git operations**:
   - ❌ `git commit`, `git tag`, `git push`
   - ✅ Pure calculation + API calls

2. **Modern release action**:
   - ❌ `actions/create-release@v1` (deprecated)
   - ✅ `softprops/action-gh-release@v2.0.8` 

3. **Respects branch protection**:
   - ❌ Direct pushes to main
   - ✅ GitHub API operations

### 📋 Benefits
✅ **No branch protection violations**  
✅ **No signing requirement conflicts**  
✅ **Works with repository rules**  
✅ **Cleaner, more maintainable workflow**  
✅ **Future-proof with modern actions**  

**Priority**: Critical - unblocks all automated releases

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Replace manual git operations in the auto-version workflow with the softprops GitHub release action to comply with branch protection and commit signing requirements and streamline release creation.

Bug Fixes:
- Remove direct git pushes and unsigned commits that violated branch protection rules

Enhancements:
- Compute semantic version bumps via inline shell logic instead of using npm version
- Update from the deprecated actions/create-release@v1 and upload-release-asset to softprops/action-gh-release@v2.0.8 for API-driven tag creation and integrated asset uploads

CI:
- Revamp .github/workflows/auto-version.yml to use GitHub API for tagging and releases instead of manual git CLI operations