### PR TITLE
fix: ensure proper newline separation in multiline output

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -115,6 +115,7 @@ jobs:
           {
             echo 'changelog<<EOF'
             cat CHANGELOG.md
+            echo
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -115,7 +115,7 @@ jobs:
           {
             echo 'changelog<<EOF'
             cat CHANGELOG.md
-            echo EOF
+            echo 'EOF'
           } >> $GITHUB_OUTPUT
 
       - name: Create deployment bundle


### PR DESCRIPTION
Fixes the persistent GitHub Actions multiline output error by adding proper newline separation.

The real issue: git log --pretty=format does not add trailing newlines, causing EOF to concatenate with the last line of content.

Solution: Add blank echo line to ensure EOF appears on its own line.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Add blank echo before closing EOF in auto-version workflow to prevent EOF from concatenating with the last line