### PR TITLE
fix: add newline before EOF delimiter in multiline output

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -115,6 +115,7 @@ jobs:
           {
             echo 'changelog<<EOF'
             cat CHANGELOG.md
+            echo
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes the persistent multiline output error in auto-version workflow.

**Problem:** GitHub Actions failing with 'Invalid value. Matching delimiter not found EOF'

**Root cause:** git log --pretty=format does not add trailing newlines, causing EOF to concatenate with changelog content.

**Solution:** Add blank echo line to ensure EOF appears on its own line.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Add a newline before the EOF delimiter in the multiline output block of the auto-version workflow to prevent delimiter concatenation