### PR TITLE
fix: use latest git tag as base version instead of package.json

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -52,7 +52,17 @@ jobs:
       - name: Get current version
         id: current_version
         run: |
-          CURRENT=$(node -p "require('./package.json').version")
+          # Get the latest version from git tags, fallback to package.json
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LATEST_TAG" ]; then
+            # Remove 'v' prefix if present
+            CURRENT=${LATEST_TAG#v}
+            echo "Using latest git tag: $LATEST_TAG (version: $CURRENT)"
+          else
+            # Fallback to package.json for initial release
+            CURRENT=$(node -p "require('./package.json').version")
+            echo "No git tags found, using package.json version: $CURRENT"
+          fi
           echo "version=$CURRENT" >> $GITHUB_OUTPUT
 
       - name: Calculate new version


### PR DESCRIPTION
Fixes version regression where releases went backwards from v1.1.0 to v1.0.1.

**Problem:** The auto-version workflow always read version from package.json, which never gets updated. This caused version conflicts when multiple releases were created.

**Timeline:**
- v1.1.0 released from commit f6254c4 (PR #251)  
- v1.0.1 released from commit fdfa0bf (PR #257) ← **REGRESSION**

**Root Cause:** package.json still shows "1.0.0", so subsequent releases calculated from there instead of the actual latest tag.

**Solution:**
- Use `git describe --tags --abbrev=0` to get the latest version
- Strip 'v' prefix for semver calculation
- Fallback to package.json only for initial releases

**Expected Next Release:** v1.1.1 (patch bump from v1.1.0)

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Use the latest git tag as the base version in the auto-version workflow to prevent version rollbacks and ensure correct semver calculation

Bug Fixes:
- Fix version regression by sourcing base version from the latest git tag instead of package.json

CI:
- Update auto-version GitHub Action to retrieve current version from the latest git tag, strip 'v' prefix, and fallback to package.json for initial releases