### PR TITLE
refactor: remove version field from package.json

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -52,16 +52,16 @@ jobs:
       - name: Get current version
         id: current_version
         run: |
-          # Get the latest version from git tags, fallback to package.json
+          # Get the latest version from git tags, fallback to 0.1.0 for initial release
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$LATEST_TAG" ]; then
             # Remove 'v' prefix if present
             CURRENT=${LATEST_TAG#v}
             echo "Using latest git tag: $LATEST_TAG (version: $CURRENT)"
           else
-            # Fallback to package.json for initial release
-            CURRENT=$(node -p "require('./package.json').version")
-            echo "No git tags found, using package.json version: $CURRENT"
+            # Fallback to 0.1.0 for initial release (package.json has no version field)
+            CURRENT="0.1.0"
+            echo "No git tags found, using initial version: $CURRENT"
           fi
           echo "version=$CURRENT" >> $GITHUB_OUTPUT
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "super_simple_tfl_status",
-  "version": "1.0.0",
   "description": "Real-time TfL service status in a minimalist design",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Eliminates the impossible-to-maintain version sync problem between package.json and git tags.

## Problem

The version field in package.json created a maintenance nightmare:
- Always became stale after first automated release  
- Created confusion about "true" version (git tags vs package.json)
- Caused version regression (v1.1.0 → v1.0.1) when workflow read stale package.json

## Solution

**Remove version field entirely** because:
- ✅ Not published to npm (no external consumers need it)
- ✅ Frontend application (deployed as static files)  
- ✅ No programmatic version access in codebase
- ✅ Git tags are single source of truth

## Changes

1. **package.json**: Remove `"version": "1.0.0"` field
2. **auto-version.yml**: Update fallback from package.json to hardcoded `0.1.0` for initial releases

## Benefits

- 🚫 No more version drift
- 🎯 Single source of truth (git tags)
- 🧹 Simpler mental model
- 🔄 Eliminates sync requirement

## Testing

Workflow will now:
- Use latest git tag as current version (primary path)
- Fall back to `0.1.0` for initial releases (fallback path - won't be needed)

Next release will properly be v1.1.1 (patch from v1.1.0).

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Remove the package.json version field to eliminate drift and rely solely on git tags for versioning, and update the auto-version workflow to fall back to a hardcoded initial release version.

Enhancements:
- Remove version field from package.json to simplify version management

CI:
- Update auto-version GitHub workflow to fallback to 0.1.0 for initial releases instead of reading package.json and to use git tags as the source of truth